### PR TITLE
Fix invalid pdf output

### DIFF
--- a/src/pdfassembler.ts
+++ b/src/pdfassembler.ts
@@ -543,6 +543,8 @@ export class PDFAssembler {
         return prefix + pdfObject;
       };
       const rootRef = newPdfObject(this.pdfTree['/Root'], 0, false);
+      this.pdfTree['/Info'].gen = 0;
+      this.pdfTree['/Info'].num = this.nextNodeNum++;
       const infoRef = this.pdfTree['/Info'] && Object.keys(this.pdfTree['/Info']).length ?
         newPdfObject(this.pdfTree['/Info'], 0, false) : null;
       const header =


### PR DESCRIPTION
Adobe's specification requires that the Info dictionary be an indirect reference.

Attempting to save generated output in Acrobat triggers this error:
"There was a problem reading this document (23)"