### PR TITLE
Use older version of pdfjs-dist as newer version breaks pdfTree

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "pako": "^1.0.6",
-    "pdfjs-dist": "^2.0.489",
+    "pdfjs-dist": "2.0.489",
     "promise-queue": "^2.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Using the latest pdfjs-dist version (as of March 2021) breaks pdfassembler - I got the following errors:

- when using getPDFStructure, ['/Root'] would be undefined
- when using resolveNodeRefs, this.pdfManager would be null

Using the older version of pdfjs-dist fixed the issue for me.